### PR TITLE
Flex layout improvements

### DIFF
--- a/exporter/src/main/as/flump/export/AnimPreviewWindow.mxml
+++ b/exporter/src/main/as/flump/export/AnimPreviewWindow.mxml
@@ -1,10 +1,10 @@
 <s:Window
     xmlns:fx="http://ns.adobe.com/mxml/2009"
-    xmlns:mx="library://ns.adobe.com/flex/mx"
     xmlns:s="library://ns.adobe.com/flex/spark"
     creationComplete="init();"
     alpha="0"
     renderMode="direct"
+    showStatusBar="false"
     width="480" height="720">
 
   <!-- I'd like to use visible="false" on the window and then set visible to true in init to hide

--- a/exporter/src/main/as/flump/export/AtlasPreviewWindow.mxml
+++ b/exporter/src/main/as/flump/export/AtlasPreviewWindow.mxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <s:Window xmlns:fx="http://ns.adobe.com/mxml/2009"
           xmlns:s="library://ns.adobe.com/flex/spark"
-          xmlns:mx="library://ns.adobe.com/flex/mx"
-          width="400" height="300">
+          width="400" height="300" showStatusBar="false">
     <s:layout>
       <s:VerticalLayout/>
     </s:layout>

--- a/exporter/src/main/as/flump/export/EditFormatsWindow.mxml
+++ b/exporter/src/main/as/flump/export/EditFormatsWindow.mxml
@@ -1,6 +1,6 @@
 <s:Window xmlns:fx="http://ns.adobe.com/mxml/2009" xmlns:mx="library://ns.adobe.com/flex/mx"
   xmlns:s="library://ns.adobe.com/flex/spark"
-  width="700" height="300" title="Export Formats">
+  width="700" height="300" title="Export Formats" showStatusBar="false">
   <s:layout>
     <s:VerticalLayout paddingLeft="20" paddingTop="20" paddingRight="20" paddingBottom="20"/>
   </s:layout>

--- a/exporter/src/main/as/flump/export/PreviewControlsWindow.mxml
+++ b/exporter/src/main/as/flump/export/PreviewControlsWindow.mxml
@@ -1,5 +1,8 @@
-<s:Window xmlns:fx="http://ns.adobe.com/mxml/2009" xmlns:mx="library://ns.adobe.com/flex/mx"
-  xmlns:s="library://ns.adobe.com/flex/spark" creationComplete="init();" width="400" height="600">
+<s:Window xmlns:fx="http://ns.adobe.com/mxml/2009"
+          xmlns:mx="library://ns.adobe.com/flex/mx"
+          xmlns:s="library://ns.adobe.com/flex/spark"
+          creationComplete="init();"
+          width="400" height="600" showStatusBar="false">
   <s:layout>
     <s:VerticalLayout paddingLeft="20" paddingTop="20" paddingRight="20" paddingBottom="20"/>
   </s:layout>

--- a/exporter/src/main/as/flump/export/ProjectWindow.mxml
+++ b/exporter/src/main/as/flump/export/ProjectWindow.mxml
@@ -1,12 +1,12 @@
 <s:Window xmlns:fx="http://ns.adobe.com/mxml/2009"
   xmlns:s="library://ns.adobe.com/flex/spark"
   xmlns:mx="library://ns.adobe.com/flex/mx"
-  width="1024" height="768">
+  width="1024" height="668" showStatusBar="false">
   <s:layout>
     <s:VerticalLayout paddingLeft="20" paddingTop="20" paddingRight="20" paddingBottom="20"/>
   </s:layout>
-  <s:HGroup>
-    <s:DataGrid id="libraries" width="480" height="300">
+  <s:HGroup height="300" width="100%">
+    <s:DataGrid id="libraries" width="480" height="100%">
       <s:typicalItem>
         <s:DataItem path="multiple/segment/nested/path/of/some/depth" modified="" valid=""/>
       </s:typicalItem>
@@ -20,7 +20,7 @@
       <mx:ArrayCollection/>
     </s:DataGrid>
     <!-- Both the Form and the FormItems need widths on them to make the percentage work -->
-    <s:VGroup width="50%">
+    <s:VGroup width="100%">
         <s:FormItem label="Import Directory" width="500">
           <s:HGroup>
             <!-- Explicitly set the width to make it line up with the export form -->
@@ -59,7 +59,7 @@
         </s:FormItem>
     </s:VGroup>
   </s:HGroup>
-  <s:DataGrid id="errors" width="100%" height="395">
+  <s:DataGrid id="errors" width="100%" height="100%">
     <s:typicalItem>
       <s:DataItem severity="Critical"
         location="multiple/segment/nested/path/of/some/depth:symbolName:layerName:12"

--- a/exporter/src/main/as/flump/export/UnsavedChangesWindow.mxml
+++ b/exporter/src/main/as/flump/export/UnsavedChangesWindow.mxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <s:TitleWindow xmlns:fx="http://ns.adobe.com/mxml/2009"
           xmlns:s="library://ns.adobe.com/flex/spark"
-          xmlns:mx="library://ns.adobe.com/flex/mx"
-          width="450" height="150">
+          width="450" height="150" >
     <s:layout>
         <s:VerticalLayout paddingLeft="20" paddingTop="20" paddingRight="20" paddingBottom="20"/>
     </s:layout>


### PR DESCRIPTION
Remove status bar added by new Flex SDKs; 
make main window fit on 1386x768 screens;
 project window error datagrid resizes with the window